### PR TITLE
docs: Update readme post migration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019-2020 Kevin Townsend (KTOWN)
+   Copyright 2019-2021 Kevin Townsend (KTOWN)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![API Documentation](doc/img/badge_api.svg)][1]
 
-[1]: https://zscilib.github.io/zscilib/
+[1]: https://zephyrproject-rtos.github.io/zscilib/
 
 The **Zephyr Scientific Library (zscilib)** is an attempt to provide a set of
 functions useful for scientific computing, data analysis and data manipulation
@@ -15,7 +15,7 @@ library is the [Zephyr Project](https://github.com/zephyrproject-rtos/zephyr),
 it tries to be as portable as possible, and a standalone reference project
 is included to use this library in non-Zephyr-based projects.
 
-This version of zscilib has been developed and tested against **Zephyr 2.6.0**.
+This version of zscilib has been developed and tested against **Zephyr 2.7.0**.
 
 ## Motivation
 
@@ -82,32 +82,6 @@ $ bin/zscilib
 ```
 
 ## Quick Start: Zephyr RTOS
-
-### Adding zscilib to your project via `west`
-
-For project that have been setup using `west`, you can add a local copy of
-zscilib by adding the following sections to `zephyr/west.yml`:
-
-1. In the `manifest/remotes` section add:
-
-```yaml
-remotes:
-  - name: zscilib
-    url-base: https://github.com/zscilib
-```
-
-2. In the `manifest/projects` section add:
-
-```yaml
-- name: zscilib
-  remote: zscilib
-  path: modules/lib/zscilib
-  revision: master
-```
-
-3. Save the file, and run `west update` from the project root to retrieve the
-latest version of zscilib from Github, or whatever `revision` was specified
-above.
 
 ### Running a sample application
 
@@ -270,10 +244,10 @@ to ensure that the stack pointer is double-word aligned).
 ## Current Features
 
 > Features marked with the
-  [v0.2.0](https://github.com/zscilib/zscilib/projects/2) flag are in progress
+  [v0.2.0](https://github.com/zephyrproject-rtos/zscilib/projects/2) flag are in progress
   or planned as part of the current release cycle, and may be partially
   implemented or stubbed at present.
-  [v0.3.0](https://github.com/zscilib/zscilib/projects/3) indicates features planned for that later release.
+  [v0.3.0](https://github.com/zephyrproject-rtos/zscilib/projects/3) indicates features planned for that later release.
 
 ### Linear Algebra
 
@@ -957,11 +931,11 @@ common text editors (Atom Beautify, for example).
 
 If you wish to contribute to this library, you can raise a PR as follows:
 
-1. Fork the repository: https://github.com/zscilib/zscilib/fork
+1. Fork the repository: https://github.com/zephyrproject-rtos/zscilib/fork
 2. `git clone` your forked repository.
 3. Update your local repo and commit any changes.
 4. Push the changes out to your fork on Github.
-5. Navigate to https://github.com/zscilib/zscilib and to the
+5. Navigate to https://github.com/zephyrproject-rtos/zscilib and to the
    right of the **Branch** menu click **New pull request**.
 6. Fill out the form that is presented.
 7. Click the **Create Pull Request** button to submit the PR.
@@ -969,7 +943,7 @@ If you wish to contribute to this library, you can raise a PR as follows:
 Also have a look at the [Issues][4] page to see if there is any outstanding
 work or issues that you might be able to help with!
 
-[4]: https://github.com/zscilib/zscilib/issues
+[4]: https://github.com/zephyrproject-rtos/zscilib/issues
 
 ## License
 


### PR DESCRIPTION
Updates the base readme file to reflect zscilib being migrated
to zephyr project as the new upstream location.

Signed-off-by: Kevin Townsend <kevin@ktownsend.com>