### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/include/zsl/instrumentation.h
+++ b/include/zsl/instrumentation.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_ZSL_INSTRUMENTATION_H__
 #define ZEPHYR_INCLUDE_ZSL_INSTRUMENTATION_H__
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zsl/zsl.h>
 

--- a/include/zsl/instrumentation.h
+++ b/include/zsl/instrumentation.h
@@ -7,8 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_ZSL_INSTRUMENTATION_H__
 #define ZEPHYR_INCLUDE_ZSL_INSTRUMENTATION_H__
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 #include <zsl/zsl.h>
 
 /**

--- a/samples/benchmarking/src/main.c
+++ b/samples/benchmarking/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 #include <zsl/zsl.h>
 #include <zsl/vectors.h>
 #include <zsl/instrumentation.h>

--- a/samples/benchmarking/src/main.c
+++ b/samples/benchmarking/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zsl/zsl.h>
 #include <zsl/vectors.h>

--- a/samples/matrix/mult/src/main.c
+++ b/samples/matrix/mult/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 

--- a/samples/matrix/mult/src/main.c
+++ b/samples/matrix/mult/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 

--- a/samples/matrix/pinv/src/main.c
+++ b/samples/matrix/pinv/src/main.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include "zsl/vectors.h"

--- a/samples/matrix/pinv/src/main.c
+++ b/samples/matrix/pinv/src/main.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include "zsl/vectors.h"

--- a/samples/matrix/svd/src/main.c
+++ b/samples/matrix/svd/src/main.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include "zsl/vectors.h"

--- a/samples/matrix/svd/src/main.c
+++ b/samples/matrix/svd/src/main.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include "zsl/vectors.h"

--- a/samples/orientation/apitest/src/main.c
+++ b/samples/orientation/apitest/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zsl/zsl.h>
 #include <zsl/orientation/orientation.h>

--- a/samples/orientation/apitest/src/main.c
+++ b/samples/orientation/apitest/src/main.c
@@ -5,8 +5,8 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 #include <zsl/zsl.h>
 #include <zsl/orientation/orientation.h>
 #include <zsl/instrumentation.h>

--- a/samples/orientation/hwtester/src/main.c
+++ b/samples/orientation/hwtester/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/sensor.h>

--- a/samples/orientation/hwtester/src/main.c
+++ b/samples/orientation/hwtester/src/main.c
@@ -5,10 +5,10 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
 #include <zsl/zsl.h>
 #include <zsl/orientation/orientation.h>
 #include <zsl/instrumentation.h>

--- a/samples/physics/gravitation/src/main.c
+++ b/samples/physics/gravitation/src/main.c
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/gravitation.h>
 #include <zsl/physics/energy.h>

--- a/samples/physics/gravitation/src/main.c
+++ b/samples/physics/gravitation/src/main.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <math.h>
 #include <errno.h>
-#include <kernel.h>
-#include <zephyr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/zephyr.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/gravitation.h>
 #include <zsl/physics/energy.h>

--- a/samples/physics/kinematics/src/main.c
+++ b/samples/physics/kinematics/src/main.c
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/kinematics.h>
 

--- a/samples/physics/kinematics/src/main.c
+++ b/samples/physics/kinematics/src/main.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <math.h>
 #include <errno.h>
-#include <kernel.h>
-#include <zephyr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/zephyr.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/kinematics.h>
 

--- a/samples/physics/momentum/src/main.c
+++ b/samples/physics/momentum/src/main.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <math.h>
 #include <errno.h>
-#include <kernel.h>
-#include <zephyr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/zephyr.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/momentum.h>
 

--- a/samples/physics/momentum/src/main.c
+++ b/samples/physics/momentum/src/main.c
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/momentum.h>
 

--- a/samples/physics/projectiles/src/main.c
+++ b/samples/physics/projectiles/src/main.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <math.h>
 #include <errno.h>
-#include <kernel.h>
-#include <zephyr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/zephyr.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/projectiles.h>
 

--- a/samples/physics/projectiles/src/main.c
+++ b/samples/physics/projectiles/src/main.c
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/projectiles.h>
 

--- a/samples/probability/apitest/src/main.c
+++ b/samples/probability/apitest/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zsl/zsl.h>
 #include <zsl/probability.h>

--- a/samples/probability/apitest/src/main.c
+++ b/samples/probability/apitest/src/main.c
@@ -5,8 +5,8 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 #include <zsl/zsl.h>
 #include <zsl/probability.h>
 

--- a/samples/shell/src/main.c
+++ b/samples/shell/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 #include <zsl/colorimetry.h>
 
 void main(void)

--- a/samples/shell/src/main.c
+++ b/samples/shell/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zsl/colorimetry.h>
 

--- a/samples/statistics/apitest/src/main.c
+++ b/samples/statistics/apitest/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <zsl/zsl.h>
 #include <zsl/statistics.h>
 

--- a/samples/statistics/apitest/src/main.c
+++ b/samples/statistics/apitest/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/statistics.h>
 

--- a/src/chemistry.c
+++ b/src/chemistry.c
@@ -6,7 +6,7 @@
 
 #include <math.h>
 #include <errno.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/chemistry.h>
 

--- a/src/colorimetry/shell.c
+++ b/src/colorimetry/shell.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <ctype.h>
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 #include <zsl/colorimetry.h>
 
 #if CONFIG_ZSL_SHELL_CLR

--- a/src/interp.c
+++ b/src/interp.c
@@ -6,7 +6,7 @@
 
 #include <math.h>
 #include <errno.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/interp.h>
 

--- a/src/orientation/shell.c
+++ b/src/orientation/shell.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <ctype.h>
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 #include <zsl/orientation/orientation.h>
 
 #if CONFIG_ZSL_SHELL_ORIENT

--- a/src/shell.c
+++ b/src/shell.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <ctype.h>
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 #include <zsl/zsl.h>
 
 #if CONFIG_ZSL_SHELL

--- a/tests/src/clr_conv.c
+++ b/tests/src/clr_conv.c
@@ -5,7 +5,7 @@
  */
 
 #include <ztest.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include <zsl/colorimetry.h>
 #include "floatcheck.h"
 #include "data.h"

--- a/tests/src/floatcheck.h
+++ b/tests/src/floatcheck.h
@@ -14,7 +14,7 @@
 #ifndef ZEPHYR_INCLUDE_ZSL_FLOATCHECK_H_
 #define ZEPHYR_INCLUDE_ZSL_FLOATCHECK_H_
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdint.h>
 #include <zsl/zsl.h>
 

--- a/tests/src/floatcheck.h
+++ b/tests/src/floatcheck.h
@@ -14,7 +14,7 @@
 #ifndef ZEPHYR_INCLUDE_ZSL_FLOATCHECK_H_
 #define ZEPHYR_INCLUDE_ZSL_FLOATCHECK_H_
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <stdint.h>
 #include <zsl/zsl.h>
 


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.