### PR TITLE
CI improvements: Adds M55, enable tests on module.yaml

### DIFF
--- a/tests/testcase.yaml
+++ b/tests/testcase.yaml
@@ -5,13 +5,13 @@ common:
 tests:
   # C functions in double precision
   zsl.core.c.double:
-    platform_allow: mps2_an521
+    platform_allow: mps2_an521 mps3_an547
     extra_configs:
       - CONFIG_ZSL_SINGLE_PRECISION=n
       - CONFIG_ZSL_PLATFORM_OPT=0
   # C functions in single precision
   zsl.core.c.single:
-    platform_allow: mps2_an521
+    platform_allow: mps2_an521 mps3_an547
     extra_configs:
       - CONFIG_ZSL_SINGLE_PRECISION=y
       - CONFIG_ZSL_PLATFORM_OPT=0

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,7 @@
 build:
   cmake: .
   kconfig: Kconfig.zscilib
+  samples:
+    - samples
+  tests:
+    - tests


### PR DESCRIPTION
- Adds the Cortex-M55 to the test suite (mps3_an547)
- Sets to samples and tests folders in `zephyr/module.yaml`