### PR TITLE
fusion: mahony: add PI controller integral limit

### DIFF
--- a/include/zsl/orientation/fusion/mahony.h
+++ b/include/zsl/orientation/fusion/mahony.h
@@ -49,6 +49,11 @@ struct zsl_fus_mahn_cfg {
 	zsl_real_t ki;
 
 	/**
+	 * @brief Integral limit for the integrator to avoid windup. Must be greater than 0
+	 */
+	zsl_real_t integral_limit;
+	
+	/**
 	 * @brief Integral feedback vector, which is updated every iteration.
 	 *        Its initial value must be (0, 0, 0).
 	 */

--- a/samples/orientation/apitest/src/main.c
+++ b/samples/orientation/apitest/src/main.c
@@ -29,6 +29,7 @@ static zsl_real_t _mahn_intfb[3] = { 0.0, 0.0, 0.0 };
 static struct zsl_fus_mahn_cfg mahn_cfg = {
 	.kp = 0.235,
 	.ki = 0.02,
+	.integral_limit = 10000.0f,
 	.intfb = {
 		.sz = 3,
 		.data = _mahn_intfb,


### PR DESCRIPTION
To avoid the wind up effect in the integrator.

Signed-off-by: Felipe Neves <felipe.neves@linaro.org>