### PR TITLE
ztest: Add missing zephyr header namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ library is the [Zephyr Project](https://github.com/zephyrproject-rtos/zephyr),
 it tries to be as portable as possible, and a standalone reference project
 is included to use this library in non-Zephyr-based projects.
 
-This version of zscilib has been developed and tested against **Zephyr 2.7.0**.
+This version of zscilib has been developed and tested against **Zephyr 3.1.0**.
 
 ## Motivation
 

--- a/tests/src/calibration_tests.c
+++ b/tests/src/calibration_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/orientation/fusion/calibration.h>
 #include "floatcheck.h"

--- a/tests/src/clr_conv.c
+++ b/tests/src/clr_conv.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zephyr/sys/printk.h>
 #include <zsl/colorimetry.h>
 #include "floatcheck.h"

--- a/tests/src/compass_tests.c
+++ b/tests/src/compass_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/orientation/compass.h>
 #include "floatcheck.h"

--- a/tests/src/complex_tests.c
+++ b/tests/src/complex_tests.c
@@ -5,7 +5,7 @@
  */
 
 #include <complex.h>    /* C99 complex number support. */
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include "floatcheck.h"
 

--- a/tests/src/data.c
+++ b/tests/src/data.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/colorimetry.h>
 
 /**

--- a/tests/src/fusion_tests.c
+++ b/tests/src/fusion_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/orientation/fusion/fusion.h>
 #include "floatcheck.h"

--- a/tests/src/interp_tests.c
+++ b/tests/src/interp_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/interp.h>
 #include "floatcheck.h"

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 
 extern void test_conv_spd_xyz(void);
 extern void test_conv_ct_xyz(void);

--- a/tests/src/matrix_tests.c
+++ b/tests/src/matrix_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/orientation_tests.c
+++ b/tests/src/orientation_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/orientation/orientation.h>
 #include "floatcheck.h"

--- a/tests/src/phy_atom_tests.c
+++ b/tests/src/phy_atom_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_dyn_tests.c
+++ b/tests/src/phy_dyn_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_ecmp_tests.c
+++ b/tests/src/phy_ecmp_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_elcty_tests.c
+++ b/tests/src/phy_elcty_tests.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_elec_tests.c
+++ b/tests/src/phy_elec_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_ener_tests.c
+++ b/tests/src/phy_ener_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_fluid_tests .c
+++ b/tests/src/phy_fluid_tests .c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_gas_tests.c
+++ b/tests/src/phy_gas_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_grav_tests.c
+++ b/tests/src/phy_grav_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_kin_tests.c
+++ b/tests/src/phy_kin_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_magn_tests.c
+++ b/tests/src/phy_magn_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_mass_tests.c
+++ b/tests/src/phy_mass_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_mom_tests.c
+++ b/tests/src/phy_mom_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_opt_tests.c
+++ b/tests/src/phy_opt_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_photon_tests.c
+++ b/tests/src/phy_photon_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_proj_tests.c
+++ b/tests/src/phy_proj_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_rot_tests.c
+++ b/tests/src/phy_rot_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_sound_tests.c
+++ b/tests/src/phy_sound_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_thermo_tests.c
+++ b/tests/src/phy_thermo_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/phy_work_tests.c
+++ b/tests/src/phy_work_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/matrices.h>
 #include <zsl/vectors.h>

--- a/tests/src/probability_tests.c
+++ b/tests/src/probability_tests.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/vectors.h>
 #include <zsl/probability.h>

--- a/tests/src/statistics_tests.c
+++ b/tests/src/statistics_tests.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/statistics.h>
 #include "floatcheck.h"

--- a/tests/src/vector_tests.c
+++ b/tests/src/vector_tests.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <zsl/zsl.h>
 #include <zsl/vectors.h>
 #include "floatcheck.h"


### PR DESCRIPTION
Adds missing `<zephyr/*>` namespace prefix to ztest header refs.

Signed-off-by: Kevin Townsend <kevin@ktownsend.com>