### PR TITLE
build: Update find_package and cmake requirements

### DIFF
--- a/samples/benchmarking/CMakeLists.txt
+++ b/samples/benchmarking/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(benchmarking)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/matrix/mult/CMakeLists.txt
+++ b/samples/matrix/mult/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mtxmult)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/matrix/pinv/CMakeLists.txt
+++ b/samples/matrix/pinv/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mtxpinv)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/matrix/svd/CMakeLists.txt
+++ b/samples/matrix/svd/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mtxsvd)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/orientation/apitest/CMakeLists.txt
+++ b/samples/orientation/apitest/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(orientation_api)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/orientation/hwtester/CMakeLists.txt
+++ b/samples/orientation/hwtester/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(orientation_api)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/physics/gravitation/CMakeLists.txt
+++ b/samples/physics/gravitation/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gravitation)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/physics/kinematics/CMakeLists.txt
+++ b/samples/physics/kinematics/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(kinematics)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/physics/momentum/CMakeLists.txt
+++ b/samples/physics/momentum/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(momentum)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/physics/projectiles/CMakeLists.txt
+++ b/samples/physics/projectiles/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(projectiles)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/probability/apitest/CMakeLists.txt
+++ b/samples/probability/apitest/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(prob_api)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/shell/CMakeLists.txt
+++ b/samples/shell/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(shell)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/statistics/apitest/CMakeLists.txt
+++ b/samples/statistics/apitest/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sta_api)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.13.1)
-find_package(Zephyr)
+# Copyright (c) 2022 Linaro
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(zsl)
 
 zephyr_include_directories(include)


### PR DESCRIPTION
Updates cmake files with the following values, to take into account requirements of Zephyr 3.1:

cmake_minimum_required(VERSION 3.20.0)
find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

Signed-off-by: Kevin Townsend <kevin@ktownsend.com>