### PR TITLE
ci: make build docs pipeline triggered

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,6 +1,8 @@
 name: Doxygen build
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [closed]
 
 jobs:
   doc-build:


### PR DESCRIPTION
only when a PR is closed.

Signed-off-by: Felipe Neves <felipe.neves@linaro.org>