### PR TITLE
ci: Make doxygen dependent on PR being merged

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   doc-build:
     name: Build Docs
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-20.04
     permissions:
       contents: write


### PR DESCRIPTION
Currently, the documentation will be rendered and updated whenever a PR is closed, even if the code wasn't merged. This update makes rendering and publishing the documentation conditional on the PR being merged.