### PR TITLE
matrices: remove the recursion on the qr decomposition

### DIFF
--- a/include/zsl/matrices.h
+++ b/include/zsl/matrices.h
@@ -633,11 +633,16 @@ int zsl_mtx_reduce(struct zsl_mtx *m, struct zsl_mtx *mr, size_t i, size_t j);
  *
  * @param m     Pointer to the input square matrix.
  * @param mred  Pointer the the reduced output square matrix.
+ * @param place1 Pointer to first placeholder matrix, it must have same size of m.
+ * @param place2 Pointer to second placeholder matrix, it must have same size of m.
  *
- * @return  0 if everything executed correctly, otherwise an appropriate
- *          error code.
+ * @return  0 if everything executed correctly, otherwise -EAGAIN to instruct
+ * 			caller to call this method again because operation is not done yet
+ * 
+ * @note this method should be called iteratively until it returns 0
  */
-int zsl_mtx_reduce_iter(struct zsl_mtx *m, struct zsl_mtx *mred);
+int zsl_mtx_reduce_iter(struct zsl_mtx *m, struct zsl_mtx *mred, 
+				struct zsl_mtx *place1, struct zsl_mtx *place2);
 
 /* NOTE: This is used for household method/QR. Should it be in the main lib? */
 /**

--- a/tests/src/matrix_tests.c
+++ b/tests/src/matrix_tests.c
@@ -1254,9 +1254,13 @@ void test_matrix_reduce(void)
 void test_matrix_reduce_iter(void)
 {
 	int rc = 0;
-
 	ZSL_MATRIX_DEF(mred, 3, 3);
 	ZSL_MATRIX_DEF(mred2, 2, 2);
+
+	/* place holder matrices for iteration*/
+	ZSL_MATRIX_DEF(place1, 4, 4);
+	ZSL_MATRIX_DEF(place2, 4, 4);
+
 
 	/* Input matrix. */
 	zsl_real_t data[16] = {  2.0, -3.0,  1.0,  5.0,
@@ -1276,7 +1280,9 @@ void test_matrix_reduce_iter(void)
 	rc = zsl_mtx_init(&mred2, NULL);
 	zassert_equal(rc, 0, NULL);
 
-	rc = zsl_mtx_reduce_iter(&m, &mred);
+	do{
+		rc = zsl_mtx_reduce_iter(&m, &mred, &place1, &place2);
+	} while(rc != 0);
 	zassert_equal(rc, 0, NULL);
 
 	/* Expected output. */
@@ -1296,7 +1302,9 @@ void test_matrix_reduce_iter(void)
 			     NULL);
 	}
 
-	rc = zsl_mtx_reduce_iter(&m, &mred2);
+	do{
+		rc = zsl_mtx_reduce_iter(&m, &mred2, &place1, &place2);
+	} while(rc != 0);
 	zassert_equal(rc, 0, NULL);
 
 	/* Expected output. */


### PR DESCRIPTION
This is not the most elegant solution, but it still remove the recursion and makes the stack cost fixed.