### PR TITLE
orientation: ahrs: fix an error in zsl_att_from_accelmag

### DIFF
--- a/src/orientation/ahrs.c
+++ b/src/orientation/ahrs.c
@@ -63,12 +63,12 @@ int zsl_att_from_accelmag(struct zsl_vec *accel, struct zsl_vec *mag,
 
 	zsl_att_from_accel(accel, &att);
 
-	zsl_real_t nom = mag_unit.data[2] * ZSL_SIN(att.pitch * ZSL_DEG_TO_RAD) -
-			 mag_unit.data[1] * ZSL_COS(att.pitch * ZSL_DEG_TO_RAD);
-	zsl_real_t den = mag_unit.data[0] * ZSL_COS(att.roll * ZSL_DEG_TO_RAD) +
-			 ZSL_SIN(att.roll * ZSL_DEG_TO_RAD) *
-			 (mag_unit.data[1] * ZSL_SIN(att.pitch * ZSL_DEG_TO_RAD) +
-			  mag_unit.data[2] * ZSL_COS(att.pitch * ZSL_DEG_TO_RAD));
+	zsl_real_t nom = mag_unit.data[2] * ZSL_SIN(att.roll * ZSL_DEG_TO_RAD) -
+			 mag_unit.data[1] * ZSL_COS(att.roll * ZSL_DEG_TO_RAD);
+	zsl_real_t den = mag_unit.data[0] * ZSL_COS(att.pitch * ZSL_DEG_TO_RAD) +
+			 ZSL_SIN(att.pitch * ZSL_DEG_TO_RAD) *
+			 (mag_unit.data[1] * ZSL_SIN(att.roll * ZSL_DEG_TO_RAD) +
+			  mag_unit.data[2] * ZSL_COS(att.roll * ZSL_DEG_TO_RAD));
 
 	a->roll = att.roll;
 	a->pitch = att.pitch;

--- a/tests/src/fusion_tests.c
+++ b/tests/src/fusion_tests.c
@@ -550,19 +550,19 @@ ZTEST(zsl_tests, test_fus_complementary)
 	/* Run the complementary algorithm. */
 	rc = comp_drv.feed_handler(&a, &m, &g, NULL, &q, comp_drv.config);
 	zassert_true(rc == 0);
-	zassert_true(val_is_equal(q.r, 0.7806422574656674, 1E-6));
-	zassert_true(val_is_equal(q.i, -0.4621974380629751, 1E-6));
-	zassert_true(val_is_equal(q.j, 0.2979802370474076, 1E-6));
-	zassert_true(val_is_equal(q.k, 0.2969494442427867, 1E-6));
+	zassert_true(val_is_equal(q.r, 0.530968, 1E-6));
+	zassert_true(val_is_equal(q.i, -0.170021, 1E-6));
+	zassert_true(val_is_equal(q.j, 0.591792, 1E-6));
+	zassert_true(val_is_equal(q.k, 0.582192, 1E-6));
 
 	/* Run the complementary algorithm with inclination angle provided. */
 	zsl_quat_init(&q, ZSL_QUAT_TYPE_IDENTITY);
 	rc = comp_drv.feed_handler(&a, &m, &g, &incl, &q, comp_drv.config);
 	zassert_true(rc == 0);
-	zassert_true(val_is_equal(q.r, 0.7806422574656674, 1E-6));
-	zassert_true(val_is_equal(q.i, -0.4621974380629751, 1E-6));
-	zassert_true(val_is_equal(q.j, 0.2979802370474076, 1E-6));
-	zassert_true(val_is_equal(q.k, 0.2969494442427867, 1E-6));
+	zassert_true(val_is_equal(q.r, 0.530968, 1E-6));
+	zassert_true(val_is_equal(q.i, -0.170021, 1E-6));
+	zassert_true(val_is_equal(q.j, 0.591792, 1E-6));
+	zassert_true(val_is_equal(q.k, 0.582192, 1E-6));
 
 	/* Run the complementary algorithm without magnetometer data. */
 	zsl_quat_init(&q, ZSL_QUAT_TYPE_IDENTITY);

--- a/tests/src/orientation_tests.c
+++ b/tests/src/orientation_tests.c
@@ -87,27 +87,72 @@ ZTEST(zsl_tests, test_att_from_accelmag)
 	ZSL_VECTOR_DEF(mag, 3);
 	ZSL_VECTOR_DEF(mag2, 4);
 	struct zsl_attitude att;
-	struct zsl_attitude acmp = {
-		.roll = 131.185925,
-		.pitch = -52.790738,
-		.yaw = -58.180353
+
+	/* No roll, no pitch */
+	zsl_real_t a_no_roll_no_pitch[3] = { 0.010534, -0.101035, 8.62894 };
+	zsl_real_t b_no_roll_no_pitch[3] = { -1.98944, -46.3991, 33.2625 };
+	struct zsl_attitude acmp_no_roll_no_pitch = {
+		.roll = -0.67084,
+		.pitch = -0.069943,
+		.yaw = 92.5274
 	};
 
-	zsl_real_t a[3] = { 7.0, 4.0, -3.5 };
-	zsl_real_t b[3] = { 0.1, -5.0, 123.0 };
-
 	/* Assign arrays to the accelerometer and magnetometer vectors. */
-	rc = zsl_vec_from_arr(&accel, a);
+	rc = zsl_vec_from_arr(&accel, a_no_roll_no_pitch);
 	zassert_true(rc == 0);
-	rc = zsl_vec_from_arr(&mag, b);
+	rc = zsl_vec_from_arr(&mag, b_no_roll_no_pitch);
 	zassert_true(rc == 0);
 
 	/* Calculate the attitude from the accelerometer vector. */
 	rc = zsl_att_from_accelmag(&accel, &mag, &att);
 	zassert_true(rc == 0);
-	zassert_true(val_is_equal(att.roll, acmp.roll, 1E-6));
-	zassert_true(val_is_equal(att.pitch, acmp.pitch, 1E-6));
-	zassert_true(val_is_equal(att.yaw, acmp.yaw, 1E-4));
+	zassert_true(val_is_equal(att.roll, acmp_no_roll_no_pitch.roll, 1E-3));
+	zassert_true(val_is_equal(att.pitch, acmp_no_roll_no_pitch.pitch, 1E-3));
+	zassert_true(val_is_equal(att.yaw, acmp_no_roll_no_pitch.yaw, 1E-3));
+
+	/* Roll, no pitch*/
+	zsl_real_t a_roll_no_pitch[3] = { 0.026934, -5.61261, 7.81001 };
+	zsl_real_t b_roll_no_pitch[3] = { -1.98364, -47.4408, 32.2177 };
+	struct zsl_attitude acmp_roll_no_pitch = {
+		.roll = -35.7027,
+		.pitch = -0.160459,
+		.yaw = 96.1766
+	};
+
+	/* Assign arrays to the accelerometer and magnetometer vectors. */
+	rc = zsl_vec_from_arr(&accel, a_roll_no_pitch);
+	zassert_true(rc == 0);
+	rc = zsl_vec_from_arr(&mag, b_roll_no_pitch);
+	zassert_true(rc == 0);
+
+	/* Calculate the attitude from the accelerometer vector. */
+	rc = zsl_att_from_accelmag(&accel, &mag, &att);
+	zassert_true(rc == 0);
+	zassert_true(val_is_equal(att.roll, acmp_roll_no_pitch.roll, 1E-3));
+	zassert_true(val_is_equal(att.pitch, acmp_roll_no_pitch.pitch, 1E-3));
+	zassert_true(val_is_equal(att.yaw, acmp_roll_no_pitch.yaw, 1E-3));
+
+	/* No roll, pitch*/
+	zsl_real_t a_no_roll_pitch[3] = { 6.82, 0.053151, 6.71526 };
+	zsl_real_t b_no_roll_pitch[3] = { 38.1413, -22.6632, 25.0115 };
+	struct zsl_attitude acmp_no_roll_pitch = {
+		.roll = 0.453488,
+		.pitch = -45.4425,
+		.yaw = 68.3648
+	};
+
+	/* Assign arrays to the accelerometer and magnetometer vectors. */
+	rc = zsl_vec_from_arr(&accel, a_no_roll_pitch);
+	zassert_true(rc == 0);
+	rc = zsl_vec_from_arr(&mag, b_no_roll_pitch);
+	zassert_true(rc == 0);
+
+	/* Calculate the attitude from the accelerometer vector. */
+	rc = zsl_att_from_accelmag(&accel, &mag, &att);
+	zassert_true(rc == 0);
+	zassert_true(val_is_equal(att.roll, acmp_no_roll_pitch.roll, 1E-3));
+	zassert_true(val_is_equal(att.pitch, acmp_no_roll_pitch.pitch, 1E-3));
+	zassert_true(val_is_equal(att.yaw, acmp_no_roll_pitch.yaw, 1E-3));
 
 	/* In this case, the dimension of the accelerometer data vector is 4, which
 	 * should return an error. */


### PR DESCRIPTION
The angles for calculating the tilt compensation were swapped.

Pitch is the movement around the y-axis, roll is the movement around the x-axis.
x-component -> data[0]
y-component -> data[1]
z-component -> data[2]

When moving around the x-axis, the x-component remains unchanged, but y- and z-component will.

So 
```
zsl_real_t nom = mag_unit.data[2] * ZSL_SIN(att.pitch * ZSL_DEG_TO_RAD) -
		   mag_unit.data[1] * ZSL_COS(att.pitch * ZSL_DEG_TO_RAD);

```
must be
```
zsl_real_t nom = mag_unit.data[2] * ZSL_SIN(att.roll * ZSL_DEG_TO_RAD) -
		mag_unit.data[1] * ZSL_COS(att.roll * ZSL_DEG_TO_RAD);

```
When moving around the y-axis, the x-component will be affected, and the y- and z-component only in conjunction with the pitch.

So
```
zsl_real_t den = mag_unit.data[0] * ZSL_COS(att.roll * ZSL_DEG_TO_RAD) +
		 ZSL_SIN(att.roll * ZSL_DEG_TO_RAD) *
		 (mag_unit.data[1] * ZSL_SIN(att.pitch * ZSL_DEG_TO_RAD) +
		  mag_unit.data[2] * ZSL_COS(att.pitch * ZSL_DEG_TO_RAD));

```
must be
```
zsl_real_t den = mag_unit.data[0] * ZSL_COS(att.pitch * ZSL_DEG_TO_RAD) +
		 ZSL_SIN(att.pitch * ZSL_DEG_TO_RAD) *
		 (mag_unit.data[1] * ZSL_SIN(att.roll * ZSL_DEG_TO_RAD) +
		  mag_unit.data[2] * ZSL_COS(att.roll * ZSL_DEG_TO_RAD));

```
This PR swaps the angles in the formula. It has been tested in an implementation.