### PR TITLE
general: update zephyr libraries

### DIFF
--- a/doc/adding_funcs.md
+++ b/doc/adding_funcs.md
@@ -129,7 +129,7 @@ to the appropriate header file mentioned earlier in this guide.
 
 #include <math.h>
 #include <errno.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/groupname.h>
 

--- a/samples/benchmarking/src/main.c
+++ b/samples/benchmarking/src/main.c
@@ -72,8 +72,9 @@ void test_vec_add(void)
 	printk("zsl_vec_add (avg): %u ns\n", instr_total / BENCH_LOOPS);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
 	printk("zscilib benchmark\n\n");
 	print_settings();
 
@@ -81,4 +82,6 @@ void main(void)
 		test_vec_add();
 		k_sleep(K_FOREVER);
 	}
+
+	return err;
 }

--- a/samples/matrix/mult/src/main.c
+++ b/samples/matrix/mult/src/main.c
@@ -48,8 +48,9 @@ void test_mtx_mult_demo(void)
 	zsl_mtx_print(&mc);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
 	printf("zscilib matrix mult demo\n\n");
 
 	test_mtx_mult_demo();
@@ -57,4 +58,6 @@ void main(void)
 	while (1) {
 		k_sleep(K_FOREVER);
 	}
+
+	return err;
 }

--- a/samples/orientation/apitest/src/main.c
+++ b/samples/orientation/apitest/src/main.c
@@ -225,8 +225,10 @@ void compass_demo(void)
 	printf("Geographic North     = %.6f\n", gn);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
+
 	printf("Orientation API demo\n");
 	printf("--------------------\n\n");
 
@@ -262,4 +264,6 @@ void main(void)
 
 	printf("Compass Test:\n");
 	compass_demo();
+
+	return err;
 }

--- a/samples/orientation/hwtester/src/main.c
+++ b/samples/orientation/hwtester/src/main.c
@@ -67,18 +67,20 @@ void sensor_timer_handler(struct k_timer *dummy)
 
 K_TIMER_DEFINE(sensor_timer, sensor_timer_handler, NULL);
 
-void main(void)
+int main(void)
 {
+	int err = 0;
+
 	/* Make sure the accel+mag was found and properly initialised. */
 	if (amtdev == NULL || !device_is_ready(amtdev)) {
 		printf("Could not get FXOS8700 device\n");
-		return;
+		return err;
 	}
 
 	/* Make sure the gyro was found and properly initialised. */
 	if (gdev == NULL || !device_is_ready(gdev)) {
 		printf("Could not get FXAS21002 device\n");
-		return;
+		return err;
 	}
 
 	printf("ns, ax, ay, az, mx, my, mz, gz, gy, gz, temp_c\n");
@@ -89,4 +91,6 @@ void main(void)
 	while (1) {
 		k_sleep(K_MSEC(100));
 	}
+
+	return err;
 }

--- a/samples/physics/gravitation/src/main.c
+++ b/samples/physics/gravitation/src/main.c
@@ -8,7 +8,6 @@
 #include <math.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/gravitation.h>
 #include <zsl/physics/energy.h>
@@ -94,9 +93,12 @@ void gravitation_demo(void)
 	printf("Its acceleration is %f meters per second squared.\n\n", g);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
 	printf("\n\nzscilib gravitation demo\n\n");
 
 	gravitation_demo();
+
+	return err;
 }

--- a/samples/physics/kinematics/src/main.c
+++ b/samples/physics/kinematics/src/main.c
@@ -8,7 +8,6 @@
 #include <math.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/kinematics.h>
 
@@ -73,9 +72,13 @@ void kinematics_demo(void)
 	printf("Its acceleration is %f meters per second squared.\n\n", accel);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
+
 	printf("\n\nzscilib kinematics demo\n\n");
 
 	kinematics_demo();
+
+	return err;
 }

--- a/samples/physics/momentum/src/main.c
+++ b/samples/physics/momentum/src/main.c
@@ -8,7 +8,6 @@
 #include <math.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/momentum.h>
 
@@ -82,9 +81,13 @@ void momentum_demo(void)
 	printf("Its final velocity would be %f m/s.\n\n", vf);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
+
 	printf("\n\nzscilib momentum demo\n\n");
 
 	momentum_demo();
+
+	return err;
 }

--- a/samples/physics/projectiles/src/main.c
+++ b/samples/physics/projectiles/src/main.c
@@ -8,7 +8,6 @@
 #include <math.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel.h>
 #include <zsl/zsl.h>
 #include <zsl/physics/projectiles.h>
 
@@ -102,10 +101,14 @@ void projectiles_demo(void)
 	printf("The total range is %f meters.\n\n", dist);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
+
 	printf("\n\nzscilib projectiles demo\n\n");
 
 	projectiles_demo();
+
+	return err;
 
 }

--- a/samples/probability/apitest/src/main.c
+++ b/samples/probability/apitest/src/main.c
@@ -112,9 +112,13 @@ void probability_demo(void)
 	printf("The probability is %f.\n\n", h);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
+
 	printf("\n\nzscilib probability demo\n\n");
 
 	probability_demo();
+
+	return err;
 }

--- a/samples/shell/src/main.c
+++ b/samples/shell/src/main.c
@@ -8,12 +8,16 @@
 #include <zephyr/sys/printk.h>
 #include <zsl/colorimetry.h>
 
-void main(void)
+int main(void)
 {
+	int err = 0;
+
 	printk("zscilib     : %s\n", zsl_version);
 	printk("\nType 'help' for command options.\n");
 
 	while (1) {
 		k_sleep(K_FOREVER);
 	}
+
+	return err;
 }

--- a/samples/statistics/apitest/src/main.c
+++ b/samples/statistics/apitest/src/main.c
@@ -392,7 +392,11 @@ void statistics_demo(void)
 	printf("    I:      %f\n", el_coef.data[8]);
 }
 
-void main(void)
+int main(void)
 {
+	int err = 0;
+
 	statistics_demo();
+
+	return err;
 }


### PR DESCRIPTION
many include macros have outdated header files
and many samples are not running as expected. Also, void main() was changed to int main() to avoid warning during compilation

fixes #69 